### PR TITLE
fix: harden CashFlow planner quality

### DIFF
--- a/ui/src/components/planner/PaymentPlanView.tsx
+++ b/ui/src/components/planner/PaymentPlanView.tsx
@@ -9,10 +9,23 @@ interface PaymentPlanViewProps {
 }
 
 export function PaymentPlanView({ plan, onDeferItem }: PaymentPlanViewProps) {
-  const schedule: ScheduleEntry[] = typeof plan.schedule === 'string'
-    ? JSON.parse(plan.schedule) : plan.schedule;
-  const warnings: PlanWarning[] = typeof plan.warnings === 'string'
-    ? JSON.parse(plan.warnings) : plan.warnings;
+  let schedule: ScheduleEntry[];
+  try {
+    const raw = typeof plan.schedule === 'string' ? JSON.parse(plan.schedule) : plan.schedule;
+    schedule = Array.isArray(raw) ? raw : [];
+  } catch (e) {
+    console.error('[PaymentPlanView] Failed to parse plan.schedule', e);
+    schedule = [];
+  }
+
+  let warnings: PlanWarning[];
+  try {
+    const raw = typeof plan.warnings === 'string' ? JSON.parse(plan.warnings) : plan.warnings;
+    warnings = Array.isArray(raw) ? raw : [];
+  } catch (e) {
+    console.error('[PaymentPlanView] Failed to parse plan.warnings', e);
+    warnings = [];
+  }
 
   // Group schedule by date
   const byDate = new Map<string, ScheduleEntry[]>();

--- a/ui/src/components/planner/ScenarioOverride.tsx
+++ b/ui/src/components/planner/ScenarioOverride.tsx
@@ -40,8 +40,8 @@ export function ScenarioOverride({ plan, strategy: _strategy, onSimulate }: Scen
     try {
       const raw = typeof plan.schedule === 'string' ? JSON.parse(plan.schedule) : plan.schedule;
       schedule = Array.isArray(raw) ? raw : [];
-    } catch {
-      console.error('[ScenarioOverride] Failed to parse plan.schedule');
+    } catch (e) {
+      console.error('[ScenarioOverride] Failed to parse plan.schedule', e);
       return [];
     }
     const seen = new Map<string, UniqueObligation>();


### PR DESCRIPTION
## Summary
- Move `useState` hooks before conditional returns to comply with React Rules of Hooks
- Add defensive JSON parsing with `try/catch` + `Array.isArray` for `plan.schedule` and `plan.warnings` in PaymentPlanView
- Clear stale error state before async operations, rollback state on failure
- Add inline error banner visible even after projections load
- Re-throw errors from `handleScenarioSimulate` so ScenarioOverride can show feedback

## Test plan
- [ ] Verify CashFlow page loads without errors on all three tabs (Forecast, Payment Planner, Revenue)
- [ ] Generate a payment plan and verify ScenarioOverride renders below it
- [ ] Defer an item in the planner and verify simulation runs
- [ ] Verify error banner appears on API failure (disconnect network, retry)
- [ ] `npm run ui:build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened payment plan data validation and parsing to ensure more reliable information display.
  * Enhanced error handling to prevent outdated errors from persisting across operations.
  * Improved error state management for more responsive interactions during async operations in payment planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->