### PR TITLE
fix(tests): mcp.test.ts scope-aware tool count (unblocks #112)

### DIFF
--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -141,15 +141,56 @@ describe('MCP — tools/list', () => {
     expect(tools.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('exposes exactly 54 tools', async () => {
+  it('exposes 50 tools to unscoped callers (triage tools hidden)', async () => {
+    // PR #104 round-3 fix: tools/list filters triage_* tools when caller
+    // lacks chittytriage:write (or admin / chittytriage:admin / *).
+    // The dev bypass in mcpAuthMiddleware grants scope `['mcp']` only, so
+    // the 4 triage tools (triage_list_intents, triage_claim_intent,
+    // triage_claim_next, triage_complete_intent) are hidden from this caller.
     const { post } = buildApp();
     const res = await post({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
     const json = await res.json() as Record<string, unknown>;
     const result = json.result as Record<string, unknown>;
-    const tools = result.tools as unknown[];
-    // 50 base + 4 triage tools added in PR #104: triage_list_intents,
-    // triage_claim_intent, triage_claim_next, triage_complete_intent
+    const tools = result.tools as Array<{ name: string }>;
+    expect(tools.length).toBe(50);
+    // None of the triage_* tools should be advertised.
+    const triageNames = [
+      'triage_list_intents',
+      'triage_claim_intent',
+      'triage_claim_next',
+      'triage_complete_intent',
+    ];
+    for (const name of triageNames) {
+      expect(tools.find((t) => t.name === name)).toBeUndefined();
+    }
+  });
+
+  it('exposes all 54 tools to callers with triage scope', async () => {
+    // When the caller's scope includes `chittytriage:write` (or admin /
+    // chittytriage:admin / *), all 4 triage tools become visible — total 54.
+    // We bypass mcpAuthMiddleware here and inject scopes directly to
+    // exercise the scoped tools/list branch deterministically (the dev
+    // bypass in mcpAuthMiddleware only grants ['mcp']).
+    const env = makeMockEnv();
+    const app = new Hono<{ Bindings: Env; Variables: AuthVariables }>();
+    app.use('/mcp/*', async (c, next) => {
+      c.set('userId', 'test-triage-user');
+      c.set('scopes', ['chittytriage:write']);
+      return next();
+    });
+    app.route('/mcp', mcpRoutes);
+    const req = new Request('http://localhost/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    const res = await app.fetch(req, env as unknown as Env);
+    const json = await res.json() as Record<string, unknown>;
+    const result = json.result as Record<string, unknown>;
+    const tools = result.tools as Array<{ name: string }>;
     expect(tools.length).toBe(54);
+    expect(tools.find((t) => t.name === 'triage_list_intents')).toBeDefined();
+    expect(tools.find((t) => t.name === 'triage_complete_intent')).toBeDefined();
   });
 
   it('each tool has a name and inputSchema', async () => {


### PR DESCRIPTION
## Summary

Pre-existing bug on `main`: PR #104 round-3 (commit aa2f2d0) added scope-based filtering of triage `*` tools from `tools/list` for unscoped callers, but did not update `tests/mcp.test.ts` which still asserted `tools.length === 54` unconditionally. The test environment uses the `mcpAuthMiddleware` dev bypass which grants only scope `['mcp']`, so the 4 triage tools are correctly filtered and only 50 are visible. The test fails on `main` and is blocking PR #112's CI build (and any other PR that runs the build).

## Changes

- Renamed the 54-tool assertion to `exposes 50 tools to unscoped callers (triage tools hidden)` and added explicit checks that none of the 4 `triage_*` tools appear in the catalog.
- Added a second test `exposes all 54 tools to callers with triage scope` that injects `scopes=['chittytriage:write']` via a custom middleware, exercising the scoped branch of `tools/list` deterministically. (The dev bypass cannot grant triage scope, and the production code path would require mocking ChittyAuth fetch — direct scope injection is cleaner.)

Both code paths are now covered.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npx vitest run tests/mcp.test.ts` — 16/16 pass (was failing on main)
- [ ] Confirms CI green on this PR, unblocking #112

## Context

This is a pre-existing `main` bug surfaced by PR #112's CI run. Merging this unblocks #112 and any other PR that runs the build.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>