### PR TITLE
chore(tests): vitest globalSetup applies migrations against DATABASE_URL

### DIFF
--- a/tests/setup/global-setup.ts
+++ b/tests/setup/global-setup.ts
@@ -1,0 +1,152 @@
+/**
+ * Vitest globalSetup — applies SQL migrations against DATABASE_URL before any
+ * integration tests run, so specs hitting a fresh Neon branch don't fail
+ * `beforeAll` with `relation "cc_*" does not exist`.
+ *
+ * The repo's migrations directory mixes two histories:
+ *   1. drizzle-kit-generated migrations tracked in `migrations/meta/_journal.json`
+ *      — the canonical schema as deployed.
+ *   2. hand-rolled SQL files (0001_command_*, 0002_command_*, ..., 0015_*) that
+ *      represent an earlier, alternative history of the same tables. These
+ *      conflict with the drizzle path (e.g., 0005_schema_alignment.sql
+ *      references the pre-consolidation `source_tx_id` column).
+ *   3. Additive, post-consolidation hand-rolled files (0017+ onwards) that
+ *      patch the drizzle schema with idempotency / decay columns the
+ *      integration suite relies on.
+ *
+ * Strategy: apply (1) in journal order, then (3) in name order. We tolerate
+ * "already exists" Postgres error codes so partially migrated branches
+ * (e.g., parent branches where some journaled migrations were applied out of
+ * band) converge cleanly. Everything else fails loudly.
+ *
+ * Skips entirely when DATABASE_URL is unset or SKIP_INTEGRATION=1.
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Pool } from '@neondatabase/serverless';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = join(__dirname, '..', '..', 'migrations');
+
+// Post-consolidation, additive hand-rolled migrations that complement the
+// journaled drizzle schema (not part of the alternative-history set).
+const ADDITIVE_PREFIXES = ['0017_', '0018_'];
+
+// Postgres SQLSTATE codes for "this object already exists" — safe to skip
+// when re-applying overlapping migration sets across branches.
+const ALREADY_EXISTS_CODES = new Set([
+  '42P07', // duplicate_table
+  '42710', // duplicate_object (constraint, type, trigger, etc.)
+  '42701', // duplicate_column
+  '42P06', // duplicate_schema
+  '42723', // duplicate_function
+  '42P16', // invalid_object_definition (e.g., duplicate index name)
+]);
+
+/**
+ * Split a SQL script on top-level `;` terminators, respecting `$$ ... $$`
+ * dollar-quoted blocks so semicolons inside PL/pgSQL function bodies don't
+ * prematurely terminate a statement.
+ */
+function splitOnSemicolons(sql: string): string[] {
+  const out: string[] = [];
+  let buf = '';
+  let inDollar = false;
+  for (let i = 0; i < sql.length; i++) {
+    const ch = sql[i];
+    if (ch === '$' && sql[i + 1] === '$') {
+      inDollar = !inDollar;
+      buf += '$$';
+      i++;
+      continue;
+    }
+    if (ch === ';' && !inDollar) {
+      const trimmed = buf.trim();
+      if (trimmed) out.push(trimmed);
+      buf = '';
+      continue;
+    }
+    buf += ch;
+  }
+  const tail = buf.trim();
+  if (tail) out.push(tail);
+  return out;
+}
+
+async function applyFile(pool: Pool, file: string): Promise<void> {
+  const path = join(MIGRATIONS_DIR, file);
+  const body = readFileSync(path, 'utf8');
+
+  // drizzle-kit migrations use `--> statement-breakpoint`; hand-rolled files
+  // use bare `;` terminators.
+  const statements = body.includes('--> statement-breakpoint')
+    ? body.split('--> statement-breakpoint').map((s) => s.trim()).filter(Boolean)
+    : splitOnSemicolons(body);
+
+  let applied = 0;
+  let skipped = 0;
+  for (const stmt of statements) {
+    if (!stmt.replace(/--.*$/gm, '').trim()) continue;
+    try {
+      await pool.query(stmt);
+      applied++;
+    } catch (err) {
+      const code = (err as { code?: string }).code;
+      if (code && ALREADY_EXISTS_CODES.has(code)) {
+        skipped++;
+        continue;
+      }
+      console.error(`[vitest globalSetup] failed applying ${file}:`, err);
+      throw err;
+    }
+  }
+  console.log(
+    `[vitest globalSetup]   ${file} — ${applied} applied, ${skipped} skipped (already exists)`,
+  );
+}
+
+export default async function globalSetup(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  const skip = process.env.SKIP_INTEGRATION === '1';
+
+  if (!databaseUrl || skip) {
+    console.log(
+      `[vitest globalSetup] Skipping migrations (DATABASE_URL=${databaseUrl ? 'set' : 'unset'}, SKIP_INTEGRATION=${process.env.SKIP_INTEGRATION ?? 'unset'})`,
+    );
+    return;
+  }
+
+  const pool = new Pool({ connectionString: databaseUrl });
+
+  try {
+    // 1. Apply journaled drizzle migrations in journal order.
+    const journalPath = join(MIGRATIONS_DIR, 'meta', '_journal.json');
+    const journal = JSON.parse(readFileSync(journalPath, 'utf8')) as {
+      entries: Array<{ tag: string }>;
+    };
+    console.log(
+      `[vitest globalSetup] Applying ${journal.entries.length} journaled migrations…`,
+    );
+    for (const entry of journal.entries) {
+      await applyFile(pool, `${entry.tag}.sql`);
+    }
+
+    // 2. Apply additive post-consolidation hand-rolled migrations.
+    const additive = readdirSync(MIGRATIONS_DIR)
+      .filter((f) => f.endsWith('.sql') && ADDITIVE_PREFIXES.some((p) => f.startsWith(p)))
+      .sort();
+    if (additive.length > 0) {
+      console.log(
+        `[vitest globalSetup] Applying ${additive.length} additive migration(s): ${additive.join(', ')}`,
+      );
+      for (const file of additive) {
+        await applyFile(pool, file);
+      }
+    }
+
+    console.log('[vitest globalSetup] migrations applied.');
+  } finally {
+    await pool.end();
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     testTimeout: 15000,
     pool: 'threads',
     maxWorkers: 1,
+    globalSetup: ['./tests/setup/global-setup.ts'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Makes the integration test suite hermetic against fresh Neon branches. Specs already gate on `DATABASE_URL` but assumed the branch was already migrated. When run against a fresh Neon branch, 4 spec files failed `beforeAll` with `relation "cc_goals" does not exist`, causing all 26 integration tests to be skipped.

This adds a Vitest `globalSetup` that applies the canonical schema before any tests run.

## Why not just `npm run db:migrate`?

The repo's `db:migrate` script (`drizzle-kit migrate`) isn't fully wired — `drizzle.config.ts` has no `dbCredentials` — and `migrations/` mixes two histories:
1. **Journaled drizzle migrations** (`meta/_journal.json`) — the canonical deployed schema
2. **Hand-rolled SQL files** — partly an alternative history (e.g. `0005_schema_alignment.sql` references the pre-consolidation `source_tx_id` column), partly post-consolidation additive deltas (`0017_*`, `0018_*`)

`drizzle-kit migrate` alone wouldn't apply `0017`/`0018`, and globbing every file conflicts. So `globalSetup`:
- Reads `migrations/meta/_journal.json` and applies journaled migrations in order
- Then applies post-consolidation additive migrations (`0017_*`, `0018_*`)
- Tolerates PostgreSQL "already exists" SQLSTATE codes so partially-migrated branches converge
- Skips entirely when `DATABASE_URL` is unset or `SKIP_INTEGRATION=1`

## Test plan

- [x] Provisioned a fresh Neon branch on project `cool-bar-13270800`
- [x] **Before** (no globalSetup): all 4 spec files fail `beforeAll` with `relation "cc_goals" does not exist`, 26/26 tests skipped
- [x] **After** (with globalSetup): 3/4 spec files fully pass, 1 file (`workspace-studio-ingest`) now runs and exposes 4 unrelated app-side failures (`ON CONFLICT` arbiter mismatch with the `0018` index — a pre-existing route bug in `meta/intent.ts`, not a migration issue). 22/26 tests pass.
- [x] Verified `SKIP_INTEGRATION=1` correctly no-ops the migration apply
- [x] Test branches deleted after validation

Fixes the integration harness gap for:
- `tests/daemon/leader.spec.ts`
- `tests/daemon/leader-session.spec.ts`
- `tests/meta/intent-lifecycle.spec.ts`
- `tests/routes/workspace-studio-ingest.spec.ts`

The 4 remaining `workspace-studio-ingest` failures (ON CONFLICT predicate doesn't match the `0018` index's `status <> 'expired'` clause) are tracked separately — fixing them requires changing application code, not the test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)