### PR TITLE
fix(intent): mirror 'expired' predicate in roux_ingest ON CONFLICT

### DIFF
--- a/meta/intent.ts
+++ b/meta/intent.ts
@@ -279,6 +279,7 @@ export async function createRouxIngestIntentIdempotent(
     ON CONFLICT ((payload->'source'->>'message_id'))
       WHERE intent_type = 'roux_ingest'
         AND payload->'source'->>'message_id' IS NOT NULL
+        AND status <> 'expired'
       DO NOTHING
     RETURNING *`;
   if (inserted[0]) {


### PR DESCRIPTION
## What

Adds `AND status <> 'expired'` to the ON CONFLICT inference predicate in `createRouxIngestIntentIdempotent` (`meta/intent.ts`), mirroring the partial unique index.

## Why

PR #115 (Roux intent decay cron, migration `0018_intent_decay.sql`) recreated `cc_intents_roux_ingest_message_id_uidx` with a narrowed predicate:

```sql
WHERE intent_type = 'roux_ingest'
  AND payload->'source'->>'message_id' IS NOT NULL
  AND status <> 'expired';
```

The idempotent-insert path's `ON CONFLICT (...) WHERE ...` was **not** updated to match. Postgres requires the ON CONFLICT inference predicate to exactly match a partial unique index's `WHERE`. Without this clause, every `createRouxIngestIntentIdempotent` call would fail with:

> there is no unique or exclusion constraint matching the ON CONFLICT specification

i.e. the Roux ingest idempotency path was broken the moment #115 deployed.

## Verification

Predicate confirmed against the authoritative migration source `migrations/0018_intent_decay.sql:20-24` — the code WHERE now matches the live index WHERE exactly (3 clauses, same order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ingestion conflict handling to exclude expired entries from duplicate detection, enabling re-creation of expired records instead of blocking new entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->