### PR TITLE
feat(triage): wire contextual (digested comms) into ChittyTriage intake spine

### DIFF
--- a/meta/intent.ts
+++ b/meta/intent.ts
@@ -297,6 +297,63 @@ export async function createRouxIngestIntentIdempotent(
   return { intent: rowToIntent(winner[0]), created: false };
 }
 
+/**
+ * Atomic create-or-fetch for contextual_ingest intents keyed by the contextual
+ * message id (carried as payload.source.message_id, e.g. 'ctx-msg-16884').
+ *
+ * Backed by the partial unique index `cc_intents_contextual_ingest_message_id_uidx`
+ * (migration 0019). Distinct from createRouxIngestIntentIdempotent: the
+ * ON CONFLICT arbiter predicate and the re-fetch BOTH filter
+ * intent_type='contextual_ingest', so the conflict actually fires for
+ * contextual rows (the roux helper's hardcoded 'roux_ingest' predicate does
+ * not cover them — routing contextual through it would either never dedup or,
+ * with the 0019 index present, raise a unique violation).
+ *
+ * @canon: chittycanon://core/services/chittycommand/contextual-ingest
+ */
+export async function createContextualIngestIntentIdempotent(
+  env: IntentEnv,
+  input: CreateIntentInput & { messageId: string },
+): Promise<{ intent: Intent; created: boolean }> {
+  const sql = getSql(env);
+  const initialStatus: IntentStatus =
+    input.sovereigntyAssessment?.decision === 'requires_human'
+      ? 'blocked_human'
+      : input.sovereigntyAssessment?.decision === 'blocked'
+        ? 'failed'
+        : 'pending';
+
+  const inserted = await sql`
+    INSERT INTO cc_intents
+      (plan_id, goal_id, intent_type, target_channel, payload, status, priority,
+       sovereignty_assessment, human_gate_reason, scheduled_for, privilege, space, metadata)
+    VALUES
+      (${input.planId}, ${input.goalId}, ${input.intentType},
+       ${input.targetChannel ?? null}, ${JSON.stringify(input.payload)}::jsonb,
+       ${initialStatus}, ${input.priority ?? 5},
+       ${input.sovereigntyAssessment ? JSON.stringify(input.sovereigntyAssessment) : null}::jsonb,
+       ${input.humanGateReason ?? null}, ${input.scheduledFor ?? null},
+       ${input.privilege ?? 'public'}, ${input.space ?? 'business'},
+       ${JSON.stringify(input.metadata ?? {})}::jsonb)
+    ON CONFLICT ((payload->'source'->>'message_id'))
+      WHERE intent_type = 'contextual_ingest'
+        AND payload->'source'->>'message_id' IS NOT NULL
+      DO NOTHING
+    RETURNING *`;
+  if (inserted[0]) {
+    return { intent: rowToIntent(inserted[0]), created: true };
+  }
+  const winner = await sql`
+    SELECT * FROM cc_intents
+    WHERE intent_type = 'contextual_ingest'
+      AND payload->'source'->>'message_id' = ${input.messageId}
+    LIMIT 1`;
+  if (!winner[0]) {
+    throw new Error(`ON CONFLICT path with no winning row for contextual message_id=${input.messageId}`);
+  }
+  return { intent: rowToIntent(winner[0]), created: false };
+}
+
 export async function getIntent(env: IntentEnv, id: string): Promise<Intent | null> {
   const sql = getSql(env);
   const rows = await sql`SELECT * FROM cc_intents WHERE id = ${id} LIMIT 1`;

--- a/migrations/0019_contextual_provenance.sql
+++ b/migrations/0019_contextual_provenance.sql
@@ -1,0 +1,47 @@
+-- 0019_contextual_provenance.sql
+--
+-- Provenance + sensitivity columns for the contextual (digested comms) upstream.
+--
+-- ChittyTriage intake spine (W4c): contextual → chittyrouter classify →
+-- chittycommand. Every row inferred from the contextual store is AI-derived
+-- and MUST be distinguishable from human/source-backed records:
+--   - source       = 'contextual'
+--   - source_ref   = the contextual message id (ctx-msg-<id>) / ChittyID
+--   - confidence   = classifier confidence (0..1)
+--   - status       = 'candidate'  (NOT verified — AI/inference alone)
+--   - sensitivity  = 'business' | 'legalink'  (per-edge Two-Space gate)
+--
+-- @canon: chittycanon://gov/governance#classification-axes  STATUS:PENDING
+-- @canon: chittycanon://core/services/chittycommand/contextual-ingest
+--
+-- Spine rule: a claim is `verified` only when >=1 NON-AI source backs it; AI /
+-- inference alone => `candidate`. Conflicts never auto-resolve — they raise a
+-- chittyagent-tasks item. See src/lib/contextual-ingest.ts.
+
+-- ── cc_obligations: inferred bills/debts carry full provenance ──────────────
+ALTER TABLE cc_obligations ADD COLUMN IF NOT EXISTS source text;
+ALTER TABLE cc_obligations ADD COLUMN IF NOT EXISTS source_ref text;
+ALTER TABLE cc_obligations ADD COLUMN IF NOT EXISTS confidence numeric;
+ALTER TABLE cc_obligations ADD COLUMN IF NOT EXISTS sensitivity text NOT NULL DEFAULT 'business';
+
+-- ── cc_recommendations: provenance so triage output is traceable to comms ──
+ALTER TABLE cc_recommendations ADD COLUMN IF NOT EXISTS source text;
+ALTER TABLE cc_recommendations ADD COLUMN IF NOT EXISTS source_ref text;
+ALTER TABLE cc_recommendations ADD COLUMN IF NOT EXISTS sensitivity text NOT NULL DEFAULT 'business';
+
+-- ── Dedup guard: one inferred obligation per contextual source_ref ─────────
+-- Partial so it only constrains contextual-sourced rows; other upstreams
+-- (quo, email_bills, manual) are unaffected.
+CREATE UNIQUE INDEX IF NOT EXISTS cc_obligations_contextual_source_ref_uidx
+  ON cc_obligations (source_ref)
+  WHERE source = 'contextual' AND source_ref IS NOT NULL;
+
+-- ── Idempotency for contextual_ingest intents (mirrors 0017 roux_ingest) ───
+-- Backs INSERT ... ON CONFLICT DO NOTHING so concurrent ingest runs of the
+-- same contextual message collapse to one intent.
+CREATE UNIQUE INDEX IF NOT EXISTS cc_intents_contextual_ingest_message_id_uidx
+  ON cc_intents ((payload->'source'->>'message_id'))
+  WHERE intent_type = 'contextual_ingest'
+    AND payload->'source'->>'message_id' IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_cc_obligations_source ON cc_obligations (source, status);

--- a/scripts/verify-contextual-ingest.mjs
+++ b/scripts/verify-contextual-ingest.mjs
@@ -1,0 +1,109 @@
+/**
+ * Real verification harness for the contextual → triage ingest.
+ *
+ * Runs the ACTUAL module (src/lib/contextual-ingest.ts) against:
+ *   - the contextual store (Neon delicate-moon, read)  via CONTEXTUAL_DATABASE_URL
+ *   - a cool-bar-13270800 BRANCH (write)               via DATABASE_URL
+ *
+ * The chittyagent-tasks prod token is gated (POLICY_BLOCKED_CHITTYCONNECT_
+ * UNAVAILABLE), so for the conflict→task proof we stand up a LOCAL instance of
+ * the real /api/v1/tasks endpoint, backed by the SAME branch DB
+ * (agent_tasks.tasks — chittyagent-tasks shares cool-bar's Hyperdrive). The
+ * integrations.tasksClient HTTP call therefore exercises the real client and
+ * writes a REAL row into the real agent_tasks.tasks schema on the branch.
+ *
+ * No mocks: real SQL, real schema, real classifier path (router /process is
+ * 404 in prod → deterministic feature fallback, which is real inference, not a
+ * stub). env.AI is absent outside the Worker runtime, so the AI branch is
+ * skipped and the deterministic fallback is used — recorded in classifier_via.
+ *
+ * Usage: node scripts/verify-contextual-ingest.mjs
+ *   requires env: DATABASE_URL, CONTEXTUAL_DATABASE_URL
+ */
+import http from 'node:http';
+import { neon } from '@neondatabase/serverless';
+import { ingestContextual } from '../src/lib/contextual-ingest.ts';
+
+const BRANCH_URL = process.env.DATABASE_URL;
+const CTX_URL = process.env.CONTEXTUAL_DATABASE_URL;
+if (!BRANCH_URL || !CTX_URL) {
+  console.error('Set DATABASE_URL (branch) and CONTEXTUAL_DATABASE_URL (contextual)');
+  process.exit(1);
+}
+
+const LOCAL_TASKS_TOKEN = 'verify-harness-local-token';
+const sql = neon(BRANCH_URL);
+
+// Local stand-in for chittyagent-tasks POST /api/v1/tasks, backed by the SAME
+// branch DB (real agent_tasks.tasks schema). This is the real createTask INSERT
+// from chittyentity/workers/shared/agent-tasks.ts.
+const server = http.createServer((req, res) => {
+  if (req.method !== 'POST' || !req.url.endsWith('/api/v1/tasks')) {
+    res.writeHead(404); return res.end('not found');
+  }
+  if (req.headers['authorization'] !== `Bearer ${LOCAL_TASKS_TOKEN}`) {
+    res.writeHead(403); return res.end(JSON.stringify({ success: false, error: 'Invalid token' }));
+  }
+  let body = '';
+  req.on('data', (c) => (body += c));
+  req.on('end', async () => {
+    try {
+      const i = JSON.parse(body);
+      const [row] = await sql`
+        INSERT INTO agent_tasks.tasks
+          (title, description, task_type, assigned_agent, source_agent, status, priority,
+           payload, depends_on, triage_class, urgency, needs_nick, notify_policy)
+        VALUES
+          (${i.title}, ${i.description ?? null}, ${i.task_type}, ${i.assigned_agent},
+           ${i.source_agent ?? 'chittycommand'}, 'pending', ${i.priority ?? 5},
+           ${JSON.stringify(i.payload ?? {})}, ${[]}, ${i.triage_class ?? null},
+           ${i.urgency ?? null}, ${i.needs_nick ?? false}, 'done_only')
+        RETURNING id, title, assigned_agent, status`;
+      res.writeHead(201, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ success: true, data: row }));
+    } catch (err) {
+      console.error('[local-tasks] insert failed:', err);
+      res.writeHead(500); res.end(JSON.stringify({ success: false, error: String(err) }));
+    }
+  });
+});
+
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+
+const env = {
+  DATABASE_URL: BRANCH_URL,
+  CONTEXTUAL_DATABASE_URL: CTX_URL,
+  // router /process is 404 in prod; classifier falls through to deterministic
+  // feature path (real). Set the real URL so the attempt is genuinely made.
+  CHITTYROUTER_URL: 'https://router.chitty.cc',
+  CHITTYAGENT_TASKS_URL: `http://127.0.0.1:${port}`,
+  CHITTYAGENT_TASKS_TOKEN: LOCAL_TASKS_TOKEN,
+  COMMAND_KV: { get: async () => null, put: async () => {}, delete: async () => {} },
+  // no AI binding outside the worker runtime
+};
+
+const before = (await sql`SELECT
+  (SELECT count(*) FROM cc_intents WHERE intent_type='contextual_ingest') intents,
+  (SELECT count(*) FROM cc_obligations WHERE source='contextual') obligations,
+  (SELECT count(*) FROM cc_recommendations WHERE source='contextual') recs,
+  (SELECT count(*) FROM agent_tasks.tasks WHERE source_agent='chittycommand' AND task_type='reconciliation') tasks`)[0];
+
+const result = await ingestContextual(env, sql, { limit: 50 });
+
+const after = (await sql`SELECT
+  (SELECT count(*) FROM cc_intents WHERE intent_type='contextual_ingest') intents,
+  (SELECT count(*) FROM cc_obligations WHERE source='contextual') obligations,
+  (SELECT count(*) FROM cc_recommendations WHERE source='contextual') recs,
+  (SELECT count(*) FROM agent_tasks.tasks WHERE source_agent='chittycommand' AND task_type='reconciliation') tasks`)[0];
+
+console.log('=== ingest result ===');
+console.log(JSON.stringify(result, null, 2));
+console.log('=== before → after ===');
+console.log('cc_intents(contextual_ingest):', before.intents, '→', after.intents);
+console.log('cc_obligations(contextual):   ', before.obligations, '→', after.obligations);
+console.log('cc_recommendations(contextual):', before.recs, '→', after.recs);
+console.log('agent_tasks.tasks(reconciliation/chittycommand):', before.tasks, '→', after.tasks);
+
+server.close();
+process.exit(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,13 @@ export type Env = {
   CHITTYGOV_URL?: string;
   CHITTYGOV_TOKEN?: string;
   CHITTYAGENT_SCRAPE_URL?: string;
+  // chittyagent-tasks (canonical distributed task queue) — conflict escalation
+  CHITTYAGENT_TASKS_URL?: string;
+  CHITTYAGENT_TASKS_TOKEN?: string;
+  // Contextual (digested cross-channel comms) read connection.
+  // Separate Neon project (ChittyLedger-Messaging) — NOT the command DB.
+  // @canon: contextual-store-neon-location
+  CONTEXTUAL_DATABASE_URL?: string;
   CHITTYREGISTER_URL?: string;
   CHITTYCHAT_DATA_API?: string;
   CHITTYSCHEMA_URL?: string;

--- a/src/lib/contextual-ingest.ts
+++ b/src/lib/contextual-ingest.ts
@@ -1,0 +1,502 @@
+/**
+ * contextual-ingest.ts
+ *
+ * ChittyTriage intake spine arm W4c: digested cross-channel comms
+ * (the "contextual" store) → classify via chittyrouter → chittycommand's
+ * sovereign cc_ tables.
+ *
+ * Pipeline per candidate message:
+ *   1. Pull digested signal from the contextual store (a SEPARATE Neon project,
+ *      ChittyLedger-Messaging / delicate-moon — read-only). Candidates are
+ *      messages carrying an `amount` entity plus a payee-like entity
+ *      (person/org). `date` entities give a due date; `legal_document` and
+ *      case-ref entities (#287 / #239 / 2024D007847) drive sensitivity.
+ *   2. Route/classify via chittyrouter. We attempt its intelligentRoute surface
+ *      (POST /process); the deployed edge currently does not expose it
+ *      (404) and /agents/triage/classify returns a deterministic stub, so we
+ *      fall back to the SAME model chittyrouter runs
+ *      (@cf/meta/llama-3.1-8b-instruct-fast) inline via env.AI. This is
+ *      AI-only inference — hence everything lands as `status='candidate'`.
+ *   3. Write a cc_intents row (intent_type='contextual_ingest', idempotent on
+ *      the contextual message id) — the durable intake artifact. NOTE:
+ *      cc_intents.status stays on the executor enum ('pending'); the
+ *      candidate→verified lifecycle lives on cc_obligations / cc_recommendations.
+ *   4. Write an inferred cc_obligation (status='candidate', source='contextual',
+ *      source_ref, confidence, sensitivity) — deduped on source_ref.
+ *   5. CONFLICT: if an existing obligation for the same payee has a materially
+ *      different amount, DO NOT overwrite — raise a chittyagent-tasks item
+ *      (assigned chittyagent-command). Conflicts never auto-resolve (spine rule).
+ *   6. cc_recommendations carry the same provenance so triage output is
+ *      traceable back to the originating message.
+ *
+ * Sovereignty / Two-Space: every inferred row is AI-derived → `candidate`,
+ * never `verified`. Legal / privileged-tagged signal → sensitivity='legalink'
+ * + intent privilege so it does not bleed to Business surfaces.
+ *
+ * @canon: chittycanon://gov/governance#classification-axes  STATUS:PENDING
+ * @canon: chittycanon://core/services/chittycommand/contextual-ingest
+ */
+
+import { neon, type NeonQueryFunction } from '@neondatabase/serverless';
+import type { Env } from '../index';
+import { typedRows } from './db';
+import { createGoal, createPlan, createRouxIngestIntentIdempotent } from '../../meta/intent';
+import { tasksClient } from './integrations';
+
+// Llama model chittyrouter's intelligentRoute runs (from its /health report).
+const ROUTER_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
+
+// Case refs / patterns that force legalink sensitivity + privileged intent.
+// @canon: chittyview-projection-spine — divorce 2024D007847 work product is
+// privileged even though it is business-relevant.
+const LEGAL_CASE_PATTERN = /2024D007847|#?\s?287\b|#?\s?239\b|arias\s+v\.?\s+bianchi/i;
+const LEGAL_KEYWORD_PATTERN = /\b(lawsuit|subpoena|court|hearing|motion|deposition|notice of motion|debt[-\s]?collection|collection agency)\b/i;
+
+export interface ContextualCandidate {
+  message_id: number;
+  source: string;
+  sent_at: string;
+  body_text: string;
+  amount: number;
+  amount_raw: string;
+  payee: string | null;
+  due_date: string | null;
+  has_legal_doc: boolean;
+  extraction_confidence: number;
+}
+
+export interface ClassificationResult {
+  category: string;
+  confidence: number; // 0..1
+  urgency: 'low' | 'normal' | 'high' | 'critical';
+  is_legal: boolean;
+  reasoning: string;
+  via: 'router_process' | 'inline_ai' | 'deterministic_fallback';
+}
+
+export interface ContextualIngestResult {
+  candidates_scanned: number;
+  intents_created: number;
+  obligations_created: number;
+  recommendations_created: number;
+  conflicts_raised: number;
+  skipped_duplicate: number;
+  legalink_gated: number;
+  classifier_via: Record<string, number>;
+}
+
+// ── Contextual read connection ──────────────────────────────────
+// The contextual store is a different Neon project than the command DB.
+function getContextualDb(env: Env): NeonQueryFunction<false, false> | null {
+  const conn = env.CONTEXTUAL_DATABASE_URL;
+  if (!conn) return null;
+  return neon(conn);
+}
+
+/**
+ * Pull candidate obligation signals from the contextual store.
+ * A candidate = a message with an `amount` entity. We co-resolve the strongest
+ * payee (person/org), the nearest `date`, and whether any legal_document /
+ * case-ref entity co-occurs (sensitivity driver).
+ */
+export async function fetchContextualCandidates(
+  ctxSql: NeonQueryFunction<false, false>,
+  limit: number,
+): Promise<ContextualCandidate[]> {
+  // One row per (message, amount-entity). Amount is the obligation primitive.
+  const rows = await ctxSql`
+    SELECT
+      m.message_id,
+      m.source::text                                   AS source,
+      m.sent_at                                         AS sent_at,
+      COALESCE(m.body_text, '')                         AS body_text,
+      ea.normalized_value                               AS amount_norm,
+      ea.value                                          AS amount_raw,
+      xa.confidence                                     AS extraction_confidence,
+      -- strongest co-occurring payee (org preferred over person)
+      (SELECT e2.value FROM contextual.entity_extractions x2
+         JOIN contextual.entities e2 ON e2.entity_id = x2.entity_id
+        WHERE x2.message_id = m.message_id AND e2.type IN ('org','organization','person')
+        ORDER BY (e2.type IN ('org','organization')) DESC, x2.confidence DESC NULLS LAST
+        LIMIT 1)                                        AS payee,
+      -- nearest date entity (due date hint)
+      (SELECT e3.normalized_value FROM contextual.entity_extractions x3
+         JOIN contextual.entities e3 ON e3.entity_id = x3.entity_id
+        WHERE x3.message_id = m.message_id AND e3.type = 'date'
+        ORDER BY x3.confidence DESC NULLS LAST LIMIT 1)  AS due_date_norm,
+      -- legal sensitivity driver
+      EXISTS (SELECT 1 FROM contextual.entity_extractions x4
+         JOIN contextual.entities e4 ON e4.entity_id = x4.entity_id
+        WHERE x4.message_id = m.message_id AND e4.type IN ('legal_document'))
+                                                         AS has_legal_doc
+    FROM contextual.entity_extractions xa
+    JOIN contextual.entities ea ON ea.entity_id = xa.entity_id
+    JOIN contextual.messages m  ON m.message_id  = xa.message_id
+    WHERE ea.type = 'amount'
+      AND ea.normalized_value ~ '^[0-9]+(\\.[0-9]+)?$'
+      AND (ea.normalized_value)::numeric >= 100
+      AND m.deleted_at IS NULL
+    ORDER BY m.sent_at DESC
+    LIMIT ${limit}
+  `;
+
+  return typedRows<{
+    message_id: number;
+    source: string;
+    sent_at: string;
+    body_text: string;
+    amount_norm: string;
+    amount_raw: string;
+    extraction_confidence: number | null;
+    payee: string | null;
+    due_date_norm: string | null;
+    has_legal_doc: boolean;
+  }>(rows).map((r) => ({
+    message_id: Number(r.message_id),
+    source: r.source,
+    sent_at: r.sent_at,
+    body_text: r.body_text,
+    amount: parseFloat(r.amount_norm),
+    amount_raw: r.amount_raw,
+    payee: r.payee,
+    due_date: normalizeDueDate(r.due_date_norm),
+    has_legal_doc: !!r.has_legal_doc,
+    extraction_confidence: r.extraction_confidence != null ? Number(r.extraction_confidence) : 0.5,
+  }));
+}
+
+/** Best-effort ISO date from a contextual `date` normalized_value. */
+function normalizeDueDate(v: string | null): string | null {
+  if (!v) return null;
+  const d = new Date(v);
+  if (!isNaN(d.getTime())) return d.toISOString().slice(0, 10);
+  return null;
+}
+
+/**
+ * Classify a candidate. Attempt chittyrouter intelligentRoute (POST /process);
+ * on any non-2xx / unusable shape, fall back to the same model inline via
+ * env.AI; if AI is unavailable, a deterministic feature-based fallback.
+ * All paths are AI/inference → caller writes status='candidate'.
+ */
+export async function classifyCandidate(
+  env: Env,
+  cand: ContextualCandidate,
+): Promise<ClassificationResult> {
+  const text = `${cand.body_text}`.slice(0, 1500);
+  const legalSignal =
+    cand.has_legal_doc || LEGAL_CASE_PATTERN.test(text) || LEGAL_KEYWORD_PATTERN.test(text);
+
+  // 1) chittyrouter intelligentRoute (POST /process). Returns ai.analysis with
+  //    category/priority/urgency_score when available.
+  if (env.CHITTYROUTER_URL) {
+    try {
+      const res = await fetch(`${env.CHITTYROUTER_URL}/process`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Source-Service': 'chittycommand' },
+        body: JSON.stringify({
+          from: cand.payee ?? 'unknown',
+          to: 'nick@nevershitty.com',
+          subject: (cand.body_text || '').slice(0, 120),
+          content: text,
+        }),
+        signal: AbortSignal.timeout(20000),
+      });
+      if (res.ok) {
+        const j = (await res.json()) as {
+          ai?: { analysis?: { category?: string; urgency_score?: number; priority?: string; case_related?: boolean; reasoning?: string } };
+        };
+        const a = j.ai?.analysis;
+        if (a && a.category) {
+          return {
+            category: a.category,
+            confidence: clamp01(a.urgency_score ?? 0.6),
+            urgency: mapPriority(a.priority),
+            is_legal: legalSignal || !!a.case_related || /legal|court|lawsuit|compliance/i.test(a.category),
+            reasoning: a.reasoning ?? 'chittyrouter intelligentRoute',
+            via: 'router_process',
+          };
+        }
+      }
+    } catch (err) {
+      console.warn('[contextual-ingest] router /process unavailable, falling back to inline AI:', err);
+    }
+  }
+
+  // 2) Inline AI with the SAME model chittyrouter runs.
+  if (env.AI) {
+    try {
+      const prompt =
+        `You are ChittyRouter AI classifying a financial/legal comms message into a triage signal.\n` +
+        `Message: """${text}"""\n` +
+        `Detected payee: ${cand.payee ?? 'unknown'}; amount: ${cand.amount_raw}.\n` +
+        `Respond ONLY with compact JSON: {"category":"billing|debt_collection|legal|lease|inquiry|other",` +
+        `"confidence":0.0-1.0,"urgency":"low|normal|high|critical","is_legal":true|false,"reasoning":"short"}`;
+      // ROUTER_MODEL is a valid Workers AI model id but may not be in the
+      // pinned AiModels union — cast the model id, not the binding.
+      const out = (await env.AI.run(ROUTER_MODEL as keyof AiModels, {
+        messages: [{ role: 'user', content: prompt }],
+        max_tokens: 200,
+      } as never)) as { response?: string };
+      const parsed = extractJson(out?.response ?? '');
+      if (parsed) {
+        return {
+          category: String(parsed.category ?? 'other'),
+          confidence: clamp01(Number(parsed.confidence ?? 0.6)),
+          urgency: normalizeUrgency(parsed.urgency),
+          is_legal: legalSignal || parsed.is_legal === true,
+          reasoning: String(parsed.reasoning ?? 'inline llama classification'),
+          via: 'inline_ai',
+        };
+      }
+    } catch (err) {
+      console.warn('[contextual-ingest] inline AI classify failed, using deterministic fallback:', err);
+    }
+  }
+
+  // 3) Deterministic feature fallback — real signal, not a mock: extraction
+  //    confidence scaled down (inference-only), category from legal/keyword.
+  return {
+    category: legalSignal ? 'legal' : LEGAL_KEYWORD_PATTERN.test(text) ? 'debt_collection' : 'billing',
+    confidence: clamp01(cand.extraction_confidence * 0.7),
+    urgency: legalSignal ? 'high' : 'normal',
+    is_legal: legalSignal,
+    reasoning: 'deterministic fallback (router + AI unavailable); features: amount+payee entity, legal pattern match',
+    via: 'deterministic_fallback',
+  };
+}
+
+/**
+ * Run the full contextual → triage ingest over a batch.
+ */
+export async function ingestContextual(
+  env: Env,
+  sql: NeonQueryFunction<false, false>,
+  opts: { limit?: number; ownerChittyId?: string } = {},
+): Promise<ContextualIngestResult> {
+  const limit = opts.limit ?? 50;
+  const owner = opts.ownerChittyId ?? 'nick@nevershitty.com';
+
+  const result: ContextualIngestResult = {
+    candidates_scanned: 0,
+    intents_created: 0,
+    obligations_created: 0,
+    recommendations_created: 0,
+    conflicts_raised: 0,
+    skipped_duplicate: 0,
+    legalink_gated: 0,
+    classifier_via: {},
+  };
+
+  const ctxSql = getContextualDb(env);
+  if (!ctxSql) {
+    throw new Error('[contextual-ingest] CONTEXTUAL_DATABASE_URL not set — cannot read the contextual store');
+  }
+
+  const candidates = await fetchContextualCandidates(ctxSql, limit);
+  result.candidates_scanned = candidates.length;
+
+  for (const cand of candidates) {
+    const sourceRef = `ctx-msg-${cand.message_id}`;
+    try {
+      const cls = await classifyCandidate(env, cand);
+      result.classifier_via[cls.via] = (result.classifier_via[cls.via] ?? 0) + 1;
+
+      // Per-edge Two-Space gate. legalink => privileged.
+      const sensitivity: 'business' | 'legalink' = cls.is_legal ? 'legalink' : 'business';
+      const privilege = cls.is_legal ? 'privileged' : 'public';
+      const space = sensitivity;
+      if (sensitivity === 'legalink') result.legalink_gated++;
+
+      // ── 1. cc_intents (durable intake artifact, idempotent) ──
+      // status stays on the executor enum ('pending'); provenance in payload.
+      let intentCreated = false;
+      try {
+        const goal = await createGoal(env, {
+          ownerChittyId: owner,
+          title: `contextual_ingest: ${cand.payee ?? sourceRef}`,
+          description: `Digested ${cand.source} signal — ${cand.amount_raw}`,
+          priority: cls.urgency === 'critical' ? 1 : cls.urgency === 'high' ? 2 : 5,
+          metadata: { source: 'contextual', source_ref: sourceRef },
+        });
+        const plan = await createPlan(env, {
+          goalId: goal.id,
+          title: `Ingest contextual message ${cand.message_id}`,
+          authoredBy: 'contextual-ingest',
+        });
+        const { created } = await createRouxIngestIntentIdempotent(env, {
+          planId: plan.id,
+          goalId: goal.id,
+          intentType: 'contextual_ingest',
+          targetChannel: cand.source,
+          privilege,
+          space,
+          messageId: sourceRef,
+          payload: {
+            source: {
+              channel: 'contextual',
+              message_id: sourceRef,
+              contextual_message_id: cand.message_id,
+              origin_channel: cand.source,
+              sent_at: cand.sent_at,
+            },
+            classification: cls.category,
+            classifier_via: cls.via,
+            confidence: cls.confidence,
+            amount: cand.amount,
+            payee: cand.payee,
+            due_date: cand.due_date,
+            sensitivity,
+            status: 'candidate', // lifecycle marker carried in payload, not in status column
+            reasoning: cls.reasoning,
+          },
+          metadata: { source: 'contextual', source_ref: sourceRef },
+        });
+        intentCreated = created;
+        if (created) result.intents_created++;
+      } catch (err) {
+        console.error(`[contextual-ingest] intent create failed for ${sourceRef}:`, err);
+      }
+
+      // Only fan out obligation/recommendation on a freshly created intent —
+      // idempotent re-runs skip the rest.
+      if (!intentCreated) {
+        result.skipped_duplicate++;
+        continue;
+      }
+
+      if (!cand.payee) {
+        // No payee → cannot form a meaningful obligation; intent stands as the record.
+        continue;
+      }
+
+      // ── 2. Conflict check vs existing obligations for this payee ──
+      // Existing record with a materially different amount => raise a task,
+      // never overwrite. (Existing == any non-candidate or different-source row.)
+      const existing = typedRows<{ id: string; amount_due: string | null; source: string | null; source_ref: string | null; status: string }>(
+        await sql`
+          SELECT id, amount_due, source, source_ref, status
+          FROM cc_obligations
+          WHERE lower(payee) = lower(${cand.payee})
+          ORDER BY created_at DESC
+          LIMIT 1
+        `,
+      );
+      const conflict =
+        existing[0] &&
+        existing[0].source_ref !== sourceRef &&
+        existing[0].amount_due != null &&
+        Math.abs(parseFloat(existing[0].amount_due) - cand.amount) > 1 &&
+        existing[0].source !== 'contextual';
+
+      if (conflict) {
+        const tasks = tasksClient(env);
+        const task = tasks
+          ? await tasks.createTask({
+              title: `Reconcile obligation conflict: ${cand.payee}`,
+              description:
+                `Contextual signal (${sourceRef}) infers $${cand.amount} for ${cand.payee}, ` +
+                `but existing obligation ${existing[0].id} (source=${existing[0].source ?? 'manual'}) ` +
+                `has $${existing[0].amount_due}. Values disagree — manual reconcile required.`,
+              task_type: 'reconciliation',
+              assigned_agent: 'chittyagent-command',
+              priority: 2,
+              // @canon: agent_tasks.tasks urgency enum (now|today|this_week|later)
+              urgency: cls.is_legal ? 'today' : 'this_week',
+              needs_nick: cls.is_legal,
+              payload: {
+                kind: 'obligation_amount_conflict',
+                source_ref: sourceRef,
+                payee: cand.payee,
+                inferred_amount: cand.amount,
+                existing_obligation_id: existing[0].id,
+                existing_amount: existing[0].amount_due,
+                sensitivity,
+              },
+            })
+          : null;
+        if (task) {
+          result.conflicts_raised++;
+        } else {
+          console.warn(`[contextual-ingest] conflict for ${cand.payee} but task creation failed`);
+        }
+        // We do NOT overwrite the existing record — that is what the conflict
+        // task owns. But we STILL persist the new inferred row as a clearly
+        // marked `candidate` (full provenance), so the disagreeing value is
+        // visible for reconciliation rather than silently dropped. The two
+        // rows (existing + candidate) coexist until a human/non-AI source
+        // resolves the conflict task.
+      }
+
+      // ── 3. Inferred cc_obligation (candidate, full provenance, deduped) ──
+      const dueDate = cand.due_date ?? new Date(Date.now() + 30 * 86400000).toISOString().slice(0, 10);
+      const category = cls.is_legal ? 'legal' : cls.category === 'lease' ? 'rent' : 'other';
+      const inserted = await sql`
+        INSERT INTO cc_obligations
+          (category, payee, amount_due, due_date, status, source, source_ref, confidence, sensitivity, metadata)
+        VALUES
+          (${category}, ${cand.payee}, ${cand.amount}, ${dueDate}, 'candidate',
+           'contextual', ${sourceRef}, ${cls.confidence}, ${sensitivity},
+           ${JSON.stringify({
+             origin_channel: cand.source,
+             classifier_via: cls.via,
+             classification: cls.category,
+             reasoning: cls.reasoning,
+             contextual_message_id: cand.message_id,
+           })}::jsonb)
+        ON CONFLICT (source_ref) WHERE source = 'contextual' AND source_ref IS NOT NULL
+        DO NOTHING
+        RETURNING id
+      `;
+      if (inserted[0]) {
+        result.obligations_created++;
+        const obligationId = (inserted[0] as { id: string }).id;
+
+        // ── 4. cc_recommendation tied to the inferred obligation ──
+        await sql`
+          INSERT INTO cc_recommendations
+            (obligation_id, rec_type, priority, title, reasoning, action_type,
+             model_version, confidence, suggested_amount, status, source, source_ref, sensitivity)
+          VALUES
+            (${obligationId}, ${cls.is_legal ? 'legal' : 'payment'},
+             ${cls.urgency === 'critical' ? 1 : cls.urgency === 'high' ? 2 : 4},
+             ${`Review inferred obligation: ${cand.payee} ($${cand.amount})`},
+             ${`Inferred from ${cand.source} message ${sourceRef} (confidence ${(cls.confidence * 100).toFixed(0)}%, via ${cls.via}). ` +
+               `Candidate — verify against a non-AI source before acting.`},
+             'review_candidate', ${`contextual-ingest/${cls.via}`}, ${cls.confidence},
+             ${cand.amount}, 'active', 'contextual', ${sourceRef}, ${sensitivity})
+        `;
+        result.recommendations_created++;
+      } else {
+        result.skipped_duplicate++;
+      }
+    } catch (err) {
+      console.error(`[contextual-ingest] candidate ${sourceRef} failed:`, err);
+    }
+  }
+
+  return result;
+}
+
+// ── small helpers ────────────────────────────────────────────
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0.5;
+  return Math.max(0, Math.min(1, n));
+}
+function mapPriority(p?: string): 'low' | 'normal' | 'high' | 'critical' {
+  switch ((p ?? '').toUpperCase()) {
+    case 'CRITICAL': return 'critical';
+    case 'HIGH': return 'high';
+    case 'LOW': return 'low';
+    default: return 'normal';
+  }
+}
+function normalizeUrgency(u: unknown): 'low' | 'normal' | 'high' | 'critical' {
+  const s = String(u ?? '').toLowerCase();
+  return s === 'low' || s === 'high' || s === 'critical' ? s : 'normal';
+}
+function extractJson(s: string): Record<string, unknown> | null {
+  const m = s.match(/\{[\s\S]*\}/);
+  if (!m) return null;
+  try { return JSON.parse(m[0]) as Record<string, unknown>; } catch { return null; }
+}

--- a/src/lib/contextual-ingest.ts
+++ b/src/lib/contextual-ingest.ts
@@ -40,7 +40,7 @@
 import { neon, type NeonQueryFunction } from '@neondatabase/serverless';
 import type { Env } from '../index';
 import { typedRows } from './db';
-import { createGoal, createPlan, createRouxIngestIntentIdempotent } from '../../meta/intent';
+import { createGoal, createPlan, createContextualIngestIntentIdempotent } from '../../meta/intent';
 import { tasksClient } from './integrations';
 
 // Llama model chittyrouter's intelligentRoute runs (from its /health report).
@@ -103,9 +103,14 @@ export async function fetchContextualCandidates(
   ctxSql: NeonQueryFunction<false, false>,
   limit: number,
 ): Promise<ContextualCandidate[]> {
-  // One row per (message, amount-entity). Amount is the obligation primitive.
+  // ONE candidate per message (the obligation primitive is the message, not
+  // each amount mention). A message can mention several amounts
+  // ($1,000 / $2,845 / $3,845) — we deterministically take the MAX amount as
+  // the headline obligation (largest = most material; deterministic so the
+  // dedup'd obligation is reproducible regardless of row order). DISTINCT ON
+  // (message_id) ordered by amount DESC.
   const rows = await ctxSql`
-    SELECT
+    SELECT DISTINCT ON (m.message_id)
       m.message_id,
       m.source::text                                   AS source,
       m.sent_at                                         AS sent_at,
@@ -136,9 +141,14 @@ export async function fetchContextualCandidates(
       AND ea.normalized_value ~ '^[0-9]+(\\.[0-9]+)?$'
       AND (ea.normalized_value)::numeric >= 100
       AND m.deleted_at IS NULL
-    ORDER BY m.sent_at DESC
-    LIMIT ${limit}
+    -- DISTINCT ON requires the distinct key to lead ORDER BY; pick MAX amount
+    -- per message. Outer query re-orders the collapsed set by recency + caps it.
+    ORDER BY m.message_id, (ea.normalized_value)::numeric DESC
   `;
+  // Re-order by recency and cap (the DISTINCT ON forced message_id-led order).
+  const candidatesRaw = [...(rows as Record<string, unknown>[])]
+    .sort((a, b) => new Date(String(b.sent_at)).getTime() - new Date(String(a.sent_at)).getTime())
+    .slice(0, limit);
 
   return typedRows<{
     message_id: number;
@@ -151,7 +161,7 @@ export async function fetchContextualCandidates(
     payee: string | null;
     due_date_norm: string | null;
     has_legal_doc: boolean;
-  }>(rows).map((r) => ({
+  }>(candidatesRaw).map((r) => ({
     message_id: Number(r.message_id),
     source: r.source,
     sent_at: r.sent_at,
@@ -324,7 +334,7 @@ export async function ingestContextual(
           title: `Ingest contextual message ${cand.message_id}`,
           authoredBy: 'contextual-ingest',
         });
-        const { created } = await createRouxIngestIntentIdempotent(env, {
+        const { created } = await createContextualIngestIntentIdempotent(env, {
           planId: plan.id,
           goalId: goal.id,
           intentType: 'contextual_ingest',

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -9,6 +9,7 @@ import { generatePaymentPlan, savePaymentPlan } from './payment-planner';
 import { reconcileNotionDisputes } from './dispute-sync';
 import { enqueueJob, processQueue, type ScrapeJobType } from './job-dispatcher';
 import { decayStaleRouxIntents } from './intent-decay';
+import { ingestContextual } from './contextual-ingest';
 
 /**
  * Cron sync orchestrator.
@@ -73,6 +74,25 @@ export async function runCronSync(
         recordsSynced += matchResult.matches_found;
       } catch (err) {
         console.error('[matcher] failed:', err);
+      }
+
+      // Phase 3.5: Contextual (digested comms) ingest → cc_intents/obligations.
+      // Runs BEFORE triage so the AI triage engine scores the new candidate
+      // obligations in the same cron tick. Skips cleanly if the contextual
+      // read connection is not configured.
+      if (env.CONTEXTUAL_DATABASE_URL) {
+        try {
+          const ctxResult = await ingestContextual(env, sql, { limit: 50 });
+          console.log(
+            `[cron:contextual] scanned=${ctxResult.candidates_scanned} intents=${ctxResult.intents_created} ` +
+            `obligations=${ctxResult.obligations_created} recs=${ctxResult.recommendations_created} ` +
+            `conflicts=${ctxResult.conflicts_raised} dup=${ctxResult.skipped_duplicate} legalink=${ctxResult.legalink_gated} ` +
+            `via=${JSON.stringify(ctxResult.classifier_via)}`,
+          );
+          recordsSynced += ctxResult.obligations_created;
+        } catch (err) {
+          console.error('[cron:contextual] failed:', err);
+        }
       }
 
       // Phase 4: AI triage

--- a/src/lib/integrations.ts
+++ b/src/lib/integrations.ts
@@ -1032,6 +1032,86 @@ export function notionClient(env: Env) {
   };
 }
 
+// ── chittyagent-tasks ─────────────────────────────────────────
+// Canonical distributed task queue (agent_tasks.tasks). ChittyCommand raises a
+// task here when an inferred contextual signal CONFLICTS with an existing
+// record — conflicts never auto-resolve (spine rule). Deployed at
+// tasks.chitty.cc; create via POST /api/v1/tasks (bearer auth).
+// @canon: chittycanon://core/services/chittyagent-tasks
+
+export interface CreateAgentTaskInput {
+  title: string;
+  description?: string;
+  task_type: string;
+  assigned_agent: string;
+  source_agent?: string;
+  priority?: number;
+  payload?: Record<string, unknown>;
+  // @canon: chittyentity/workers/shared/task-constants.ts — agent_tasks.tasks
+  // CHECK constraints. triage_class ∈ ignore|defer|delegate|escalate,
+  // urgency ∈ now|today|this_week|later.
+  triage_class?: 'ignore' | 'defer' | 'delegate' | 'escalate';
+  urgency?: 'now' | 'today' | 'this_week' | 'later';
+  needs_nick?: boolean;
+}
+
+export interface AgentTaskResult {
+  id: string;
+  title: string;
+  assigned_agent: string;
+  status: string;
+}
+
+export function tasksClient(env: Env) {
+  const baseUrl = env.CHITTYAGENT_TASKS_URL;
+  if (!baseUrl) return null;
+
+  async function resolveToken(): Promise<string | null> {
+    if (env.CHITTYAGENT_TASKS_TOKEN) return env.CHITTYAGENT_TASKS_TOKEN;
+    // Fall back to KV (mirrors routerClient's scrape:service_token pattern;
+    // credential delivered via CF secret / ChittyConnect, never hardcoded).
+    try {
+      return (await env.COMMAND_KV.get('tasks:service_token')) ?? null;
+    } catch (err) {
+      console.warn('[tasks] KV token read failed:', err);
+      return null;
+    }
+  }
+
+  return {
+    /** Create a task on chittyagent-tasks. Returns null on any failure. */
+    createTask: async (input: CreateAgentTaskInput): Promise<AgentTaskResult | null> => {
+      try {
+        const token = await resolveToken();
+        if (!token) {
+          console.warn('[tasks] No CHITTYAGENT_TASKS_TOKEN / tasks:service_token — cannot create task');
+          return null;
+        }
+        const res = await fetch(`${baseUrl}/api/v1/tasks`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`,
+            'X-ChittyOS-Caller': 'chittycommand',
+          },
+          body: JSON.stringify({ source_agent: 'chittycommand', ...input }),
+          signal: AbortSignal.timeout(15000),
+        });
+        if (!res.ok) {
+          const errBody = await res.text().catch(() => '');
+          console.error(`[tasks] POST /api/v1/tasks failed: ${res.status} — ${errBody.slice(0, 500)}`);
+          return null;
+        }
+        const json = await res.json() as { success: boolean; data?: AgentTaskResult };
+        return json.data ?? null;
+      } catch (err) {
+        console.error('[tasks] createTask error:', err);
+        return null;
+      }
+    },
+  };
+}
+
 // ── ChittyGov ─────────────────────────────────────────────
 // Corporate governance: compliance calendar, filing deadlines, monitors
 

--- a/src/routes/triage.ts
+++ b/src/routes/triage.ts
@@ -17,6 +17,7 @@ import { Hono } from 'hono';
 import type { Env } from '../index';
 import type { AuthVariables } from '../middleware/auth';
 import { getDb } from '../lib/db';
+import { ingestContextual } from '../lib/contextual-ingest';
 import {
   claimNextIntent,
   completeIntent,
@@ -218,4 +219,28 @@ triageRoutes.post('/:id/complete', async (c) => {
     );
   }
   return c.json({ intent: updated });
+});
+
+/**
+ * POST /api/triage/contextual/ingest — run the contextual (digested comms)
+ * intake on demand. Pulls digested signal from the contextual store, classifies
+ * via chittyrouter, and writes candidate cc_intents / cc_obligations /
+ * cc_recommendations with full provenance. Conflicts raise chittyagent-tasks.
+ *
+ * Body (optional): { "limit": number }
+ *
+ * @canon: chittycanon://core/services/chittycommand/contextual-ingest
+ */
+triageRoutes.post('/contextual/ingest', async (c) => {
+  if (!c.env.CONTEXTUAL_DATABASE_URL) {
+    return c.json({ error: 'CONTEXTUAL_DATABASE_URL not configured' }, 503);
+  }
+  let limit = 50;
+  try {
+    const body = (await c.req.json().catch(() => ({}))) as { limit?: number };
+    if (typeof body.limit === 'number' && body.limit > 0 && body.limit <= 500) limit = body.limit;
+  } catch { /* default */ }
+  const sql = getDb(c.env);
+  const result = await ingestContextual(c.env, sql, { limit });
+  return c.json({ ok: true, result });
 });


### PR DESCRIPTION
## What

Wires the **contextual** (digested cross-channel comms) store into **ChittyTriage** — the intake arm of chittycommand. Digested signal → classify via chittyrouter → chittycommand's sovereign `cc_` tables, on the canonical `candidate → verified → superseded` lifecycle with a per-edge Two-Space sensitivity gate.

This is ChittyTriage arm **W4c** of the projection spine (`contextual → chittyrouter → chittycommand integrations/triage`).

## How it follows the canon

- **Reuses the proven ladder.** `cc_intents` rows are created via the same `createGoal/createPlan/createRouxIngestIntentIdempotent` chain the Workspace-Studio `roux_ingest` path uses, with `intent_type='contextual_ingest'` and an idempotency index mirroring migration 0017.
- **`status='candidate'`, never `verified`.** Every inferred row is AI/inference-derived, so per the spine rule (verified requires ≥1 NON-AI source) obligations/recommendations land as `candidate`. `cc_intents.status` is left on the executor enum (`pending`) — the candidate marker rides in `payload`/columns, so the executor state machine is untouched.
- **Full provenance.** Every inferred row carries `source='contextual'`, `source_ref` (contextual message id, e.g. `ctx-msg-16884`), `confidence`, and `sensitivity`.
- **Dedup.** Partial unique index on `cc_obligations.source_ref` (contextual only) + `ON CONFLICT DO NOTHING`.
- **Conflict → task, never overwrite.** If an inferred amount disagrees with an existing obligation for the same payee, we raise a real `chittyagent-tasks` reconciliation item (`tasks.chitty.cc/api/v1/tasks`, assigned `chittyagent-command`) and leave the existing row intact; the candidate is still persisted so the disagreement is visible.
- **Per-edge Two-Space.** Legal/privileged signal (a `legal_document` entity, or case refs #287/#239/2024D007847) → `sensitivity='legalink'` + privileged intent, so it does not bleed to Business surfaces.

## Classifier / intelligentRoute intake path

Attempts chittyrouter's `intelligentRoute` surface (`POST /process`). **Empirically the deployed edge does not expose it (404), `/ai/route` is the known 500, and `/agents/triage/classify` returns a deterministic stub (`fallback:true`, 0.5).** Per the task's sanctioned fallback, the module then classifies inline with the **same model chittyrouter runs** (`@cf/meta/llama-3.1-8b-instruct-fast` via `env.AI`), then a deterministic feature fallback. The path used is recorded per-row in `classifier_via`.

## Files

- `src/lib/contextual-ingest.ts` — the upstream + ingest pipeline.
- `migrations/0019_contextual_provenance.sql` — provenance/sensitivity columns + dedup/idempotency indexes.
- `src/lib/integrations.ts` — `tasksClient` (chittyagent-tasks).
- `src/lib/cron.ts` — Phase 3.5 (runs before triage; skips if `CONTEXTUAL_DATABASE_URL` unset).
- `src/routes/triage.ts` — `POST /api/triage/contextual/ingest` on-demand trigger.
- `src/index.ts` — `CONTEXTUAL_DATABASE_URL`, `CHITTYAGENT_TASKS_URL/_TOKEN`.
- `scripts/verify-contextual-ingest.mjs` — real verification harness (runs the actual module).

## ⚠️ Sovereign-write gate (why verification ran on a branch)

**Production `cool-bar-13270800` (ChittyCommand) does not have `cc_intents` / `cc_goals` / `cc_plans`** — the meta-orchestrator migrations (0002+) were never applied to the live DB (confirmed: the live DB is at pre-0002 state; Hyperdrive `6f6cba43…` origin `ep-young-rain-ak3jf326` ↔ project `cool-bar-13270800`). Writing the spine to the sovereign DB is therefore gated. Per policy, build + verification ran on a **Neon branch of production** (`br-royal-morning-ak3r7dxt`) with the missing meta migrations + 0019 applied, reading the **real** contextual store (`delicate-moon-28755675`).

**Action for merge:** apply migrations 0002 (+0003 roux axes, 0017, 0018) and 0019 to production before enabling the cron phase.

A second gate: the `chittyagent-tasks` prod token and local DB-connection injection are both credential-gated (`POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE`; neonctl unauthed). So end-to-end verification used MCP `run_sql` as a SQL-faithful replay of the module's exact write path against the branch — real rows, real schema, real contextual reads; the inline AI branch (Workers-runtime only) did not execute, so the verified rows came via the deterministic fallback classifier (recorded as `classifier_via=deterministic_fallback`, `confidence = extraction_confidence × 0.7`).

## Verification evidence (real rows on the branch)

before → after:

| table | before | after |
|---|---|---|
| `cc_intents` (contextual_ingest) | 0 | 3 |
| `cc_obligations` (source=contextual) | 0 | 1 |
| `cc_recommendations` (source=contextual) | 0 | 1 |
| `agent_tasks.tasks` (reconciliation, chittycommand) | 0 | 1 |

- **Sample inferred obligation** (real openphone lease-addendum message 16884):
  `payee=Kris amount_due=1000.00 status=candidate source=contextual source_ref=ctx-msg-16884 confidence=0.665 sensitivity=legalink category=legal`
- **Conflict → task**: seeded existing `manual` Kris $500; ingest inferred $1000 → raised real `agent_tasks.tasks` row `6b29b0f4-… reconciliation / chittyagent-command / urgency=today / needs_nick / sensitivity=legalink`, payload references the existing obligation. Existing $500 row **not overwritten** — both coexist.
- **Idempotency**: re-running the obligation insert → 0 new rows; Kris obligation count stays 1.
- **Sensitivity gating**: legal-tagged Kris → `legalink` on intent space + obligation + task; the two payee-null bills (ctx-msg-6398 $1,912.50, ctx-msg-6501 $5,300) → `business`.

## Known spec note

The task said triage "picks up candidate obligations," but `runTriage()` filters `status IN ('pending','overdue')` — candidates are intentionally excluded (the emphatic "do NOT write verified/trusted from inference" instruction wins). Promotion `candidate → pending` should happen on verification by a non-AI source (future follow-up), not at ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update (review fixes)

- **Intent idempotency corrected.** Initial revision routed `contextual_ingest` through `createRouxIngestIntentIdempotent`, whose `ON CONFLICT`/re-fetch are hardcoded to `intent_type='roux_ingest'` — so contextual intents never deduped (and, with the 0019 index present, the second insert raised a unique violation), causing unbounded goal/plan/intent fan-out per cron tick. Added a dedicated `createContextualIngestIntentIdempotent` whose arbiter predicate + re-fetch both filter `intent_type='contextual_ingest'`, targeting the 0019 index. **Re-verified on branch: two inserts of a fresh contextual message_id → exactly 1 intent row.**
- **Deterministic amount.** A message can mention several amounts; `fetchContextualCandidates` now collapses to one candidate per message (`DISTINCT ON (message_id)`, MAX amount), so the deduped obligation is reproducible regardless of row order.
- **Claim accuracy.** Under the credential gates the JS classifier (router `/process` → inline llama → deterministic fallback) was **type-checked but not executed**; the verified rows carry values equivalent to the deterministic-fallback path (`classifier_via=deterministic_fallback`, `confidence = extraction_confidence × 0.7 = 0.665`). The router and inline-AI branches are execution-unverified (they run only in the Workers runtime / with a reachable router).
- **Phase ordering note.** Phase 3.5 runs before triage purely for ordering; it does **not** cause candidates to be scored — `runTriage` filters `status IN ('pending','overdue')` and excludes `candidate` by design (promotion to `pending` happens on non-AI verification, a follow-up).
