### PR TITLE
ci: scope build-job npm audit gate to production dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,12 @@ jobs:
       - name: Install
         run: npm ci
       - name: Dependency Audit
-        run: npm audit --audit-level=high
+        # Scope the High+ gate to production dependencies shipped to the Worker
+        # runtime. All current High/Moderate advisories are in dev-only tooling
+        # (esbuild, vite, ws via wrangler / drizzle-kit / vitest) with no
+        # non-breaking fix; the runtime dependency tree is clean. Mirrors the
+        # audit_omit_dev option already exposed by reusable-governance-gates.yml.
+        run: npm audit --audit-level=high --omit=dev
       - name: Typecheck
         run: npx tsc -p tsconfig.json --noEmit
       - name: Test


### PR DESCRIPTION
## What

Adds `--omit=dev` to the `build` job's dependency-audit step in `.github/workflows/ci.yml`, scoping the High+ `npm audit` gate to the **production** dependency tree.

```diff
- run: npm audit --audit-level=high
+ run: npm audit --audit-level=high --omit=dev
```

## Why

The `build` check fails **repo-wide** (on `main` and on every PR) at the audit step. Every current advisory is in **dev-only tooling**, none of which ships to the Cloudflare Worker runtime:

| Advisory | Severity | Reaches build via (all `devDependencies`) |
|---|---|---|
| `esbuild` 0.17–0.28 | high | `wrangler`, `drizzle-kit`, `vite` (← `vitest`), `esbuild-register` |
| `ws` 8.0–8.20 | moderate | `miniflare` (← `wrangler` / `vitest`) |

The runtime `dependencies` (`hono`, `drizzle-orm`, `zod`, `jose`, `ai`, `@neondatabase/serverless`, …) are clean. The only `npm audit fix` available is a set of **breaking** major upgrades (`wrangler@3.6.0`, `drizzle-kit@0.19.1`).

## Why this is scoping, not a bypass

- `--omit=dev` audits exactly the code that is **deployed** to the Worker. Build-time tooling (esbuild, the wrangler dev server, drizzle-kit, the vitest/vite test stack) is not part of the runtime attack surface.
- This mirrors the **`audit_omit_dev`** input the org already exposes in `reusable-governance-gates.yml` (`npm audit --audit-level=high ${{ inputs.audit_omit_dev && '--omit=dev' || '' }}`) — a sanctioned pattern, applied here to the inline `ci.yml` step.
- The gate is **not** weakened for shipped code, and dev-tooling advisories remain tracked via Dependabot on the default branch.

## Verification

```
$ npm audit --omit=dev --audit-level=high
found 0 vulnerabilities    # exit 0
```

(vs. `npm audit --audit-level=high` → 9 vulnerabilities, exit 1, all dev-only.)

## Scope

- CI-only change; no application code, dependencies, or lockfile touched.
- Decoupled from the docs PR (#123) per request — that PR's red `build` check is this same gate and will clear once this lands and #123 is rebased.

https://claude.ai/code/session_01886crB52Jw3LWiqPh33WUM

---
_Generated by [Claude Code](https://claude.ai/code/session_01886crB52Jw3LWiqPh33WUM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to scope dependency audits to production dependencies shipped in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->